### PR TITLE
Add a check for deprecated references.

### DIFF
--- a/src/main/java/org/incenp/obofoundry/odk/CheckCommand.java
+++ b/src/main/java/org/incenp/obofoundry/odk/CheckCommand.java
@@ -1,0 +1,120 @@
+/*
+ * ODK ROBOT Plugin
+ * Copyright © 2025 Damien Goutte-Gattat
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.incenp.obofoundry.odk;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.cli.CommandLine;
+import org.obolibrary.robot.CommandLineHelper;
+import org.obolibrary.robot.CommandState;
+import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLEntity;
+import org.semanticweb.owlapi.model.OWLObjectProperty;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.parameters.Imports;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CheckCommand extends BasePlugin {
+
+    private static final Logger logger = LoggerFactory.getLogger(CheckCommand.class);
+
+    private Set<String> basePrefixes = new HashSet<>();
+
+    public CheckCommand() {
+        super("check", "perform some checks on an ontology", "robot check --checks [CHECK,...]");
+
+        options.addOption("c", "checks", true, "list of checks to perform");
+        options.addOption(null, "base-iri", true, "only check entities in the indicated namespace(s)");
+        options.addOption("x", "fail", true, "if true, fail if any of the checks fails");
+    }
+
+    @Override
+    public void performOperation(CommandState state, CommandLine line) throws Exception {
+        for ( String prefix : CommandLineHelper.getOptionalValues(line, "base-iri") ) {
+            basePrefixes.add(getIRI(prefix, "base-iri").toString());
+        }
+
+        int failed = 0;
+        for ( String check : line.getOptionValues("checks") ) {
+            switch ( check ) {
+            case "deprecated-references":
+                if ( !checkDeprecatedReferences(state.getOntology()) ) {
+                    logger.error("The ontology contains references to deprecated entities");
+                    failed += 1;
+                }
+                break;
+            }
+        }
+
+        if ( failed > 0 && CommandLineHelper.getBooleanValue(line, "fail", false) ) {
+            System.exit(1);
+        }
+    }
+
+    private boolean checkDeprecatedReferences(OWLOntology ontology) {
+        boolean pass = true;
+        for ( OWLEntity entity : ontology.getSignature(Imports.INCLUDED) ) {
+            if ( !isInBase(entity.getIRI().toString()) || isDeprecated(ontology, entity) ) {
+                continue;
+            }
+
+            Set<OWLAxiom> axioms = new HashSet<>();
+            if ( entity instanceof OWLClass ) {
+                axioms.addAll(ontology.getAxioms((OWLClass) entity, Imports.INCLUDED));
+            } else if ( entity instanceof OWLObjectProperty ) {
+                axioms.addAll(ontology.getAxioms((OWLObjectProperty) entity, Imports.INCLUDED));
+            }
+
+            for ( OWLAxiom axiom : axioms ) {
+                for ( OWLEntity referenced : axiom.getSignature() ) {
+                    if ( isDeprecated(ontology, referenced) ) {
+                        pass = false;
+                        logger.warn("{} references deprecated entity {}", entity.getIRI(), referenced.getIRI());
+                    }
+                }
+            }
+        }
+
+        return pass;
+    }
+
+    private boolean isDeprecated(OWLOntology ontology, OWLEntity entity) {
+        for ( OWLOntology ont : ontology.getImportsClosure() ) {
+            for ( OWLAnnotationAssertionAxiom ax : ont.getAnnotationAssertionAxioms(entity.getIRI()) ) {
+                if ( ax.isDeprecatedIRIAssertion() ) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean isInBase(String iri) {
+        for ( String base : basePrefixes ) {
+            if ( iri.startsWith(base) ) {
+                return true;
+            }
+        }
+        return basePrefixes.isEmpty();
+    }
+}

--- a/src/main/java/org/incenp/obofoundry/odk/CheckCommand.java
+++ b/src/main/java/org/incenp/obofoundry/odk/CheckCommand.java
@@ -19,8 +19,10 @@
 package org.incenp.obofoundry.odk;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.cli.CommandLine;
@@ -44,6 +46,7 @@ public class CheckCommand extends BasePlugin {
     private static final Logger logger = LoggerFactory.getLogger(CheckCommand.class);
 
     private Set<String> basePrefixes = new HashSet<>();
+    private Map<OWLEntity, Boolean> cache = new HashMap<>();
 
     public CheckCommand() {
         super("check", "perform some checks on an ontology", "robot check --checks [CHECK,...]");
@@ -58,6 +61,7 @@ public class CheckCommand extends BasePlugin {
         for ( String prefix : CommandLineHelper.getOptionalValues(line, "base-iri") ) {
             basePrefixes.add(getIRI(prefix, "base-iri").toString());
         }
+        cache.clear();
 
         int failed = 0;
         for ( String check : line.getOptionValues("checks") ) {
@@ -128,13 +132,20 @@ public class CheckCommand extends BasePlugin {
     }
 
     private boolean isDeprecated(OWLOntology ontology, OWLEntity entity) {
+        Boolean cached = cache.get(entity);
+        if ( cached != null ) {
+            return cached;
+        }
+
         for ( OWLOntology ont : ontology.getImportsClosure() ) {
             for ( OWLAnnotationAssertionAxiom ax : ont.getAnnotationAssertionAxioms(entity.getIRI()) ) {
                 if ( ax.isDeprecatedIRIAssertion() ) {
+                    cache.put(entity, true);
                     return true;
                 }
             }
         }
+        cache.put(entity, false);
         return false;
     }
 

--- a/src/main/java/org/incenp/obofoundry/odk/CheckCommand.java
+++ b/src/main/java/org/incenp/obofoundry/odk/CheckCommand.java
@@ -18,7 +18,9 @@
 
 package org.incenp.obofoundry.odk;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.cli.CommandLine;
@@ -27,7 +29,10 @@ import org.obolibrary.robot.CommandState;
 import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLClassAxiom;
+import org.semanticweb.owlapi.model.OWLDataProperty;
 import org.semanticweb.owlapi.model.OWLEntity;
+import org.semanticweb.owlapi.model.OWLNamedIndividual;
 import org.semanticweb.owlapi.model.OWLObjectProperty;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.parameters.Imports;
@@ -83,6 +88,10 @@ public class CheckCommand extends BasePlugin {
                 axioms.addAll(ontology.getAxioms((OWLClass) entity, Imports.INCLUDED));
             } else if ( entity instanceof OWLObjectProperty ) {
                 axioms.addAll(ontology.getAxioms((OWLObjectProperty) entity, Imports.INCLUDED));
+            } else if ( entity instanceof OWLDataProperty ) {
+                axioms.addAll(ontology.getAxioms((OWLDataProperty) entity, Imports.INCLUDED));
+            } else if ( entity instanceof OWLNamedIndividual ) {
+                axioms.addAll(ontology.getAxioms((OWLNamedIndividual) entity, Imports.INCLUDED));
             }
 
             for ( OWLAxiom axiom : axioms ) {
@@ -91,6 +100,26 @@ public class CheckCommand extends BasePlugin {
                         pass = false;
                         logger.warn("{} references deprecated entity {}", entity.getIRI(), referenced.getIRI());
                     }
+                }
+            }
+        }
+
+        for ( OWLOntology ont : ontology.getImportsClosure() ) {
+            for ( OWLClassAxiom gca : ont.getGeneralClassAxioms() ) {
+                boolean hasEntitiesInBase = false;
+                List<String> deprecatedEntities = new ArrayList<>();
+                for ( OWLEntity referenced : gca.getSignature() ) {
+                    if ( isInBase(referenced.getIRI().toString()) ) {
+                        hasEntitiesInBase = true;
+                    }
+                    if ( isDeprecated(ontology, referenced) ) {
+                        deprecatedEntities.add(referenced.getIRI().toString());
+                    }
+                }
+                if ( hasEntitiesInBase && !deprecatedEntities.isEmpty() ) {
+                    pass = false;
+                    logger.warn("A general class axiom references deprecated entities: {}",
+                            String.join(", ", deprecatedEntities));
                 }
             }
         }

--- a/src/main/resources/META-INF/services/org.obolibrary.robot.Command
+++ b/src/main/resources/META-INF/services/org.obolibrary.robot.Command
@@ -2,3 +2,4 @@ org.incenp.obofoundry.odk.NormalizeCommand
 org.incenp.obofoundry.odk.SubsetCommand
 org.incenp.obofoundry.odk.CheckAlignmentCommand
 org.incenp.obofoundry.odk.ImportCommand
+org.incenp.obofoundry.odk.CheckCommand


### PR DESCRIPTION
This PR adds a new `check` command intended to perform some additional checks (beyond those already performed by ROBOT) on an ontology.

For now, the only check is a check that no class and no object property is defined relatively to a deprecated entity.