### PR TITLE
Add odk:obsolete-replace command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ The following commands are provided by the plugin:
 * `odk:subset`: to create ontology subsets;
 * `odk:check-align`: to check the alignment of an ontology against an
   upper-level ontology and/or arbitrary root terms;
-* `odk:normalize`: to “normalise” an ontology,
-* `odk:import`: to add/remove import declarations.
+* `odk:normalize`: to "normalise" an ontology;
+* `odk:import`: to add/remove import declarations;
+* `odk:obsolete-replace`: to obsolete an entity and replace all its usages
+  with another entity.
 
 Building
 --------

--- a/src/main/java/org/incenp/obofoundry/odk/Constants.java
+++ b/src/main/java/org/incenp/obofoundry/odk/Constants.java
@@ -39,4 +39,16 @@ public class Constants {
     public static final IRI COB_IRI = IRI.create("http://purl.obolibrary.org/obo/cob.owl");
 
     public static final IRI PREFERRED_ROOT_PROPERTY = IRI.create("http://purl.obolibrary.org/obo/IAO_0000700");
+
+    public static final IRI RDFS_LABEL = IRI.create("http://www.w3.org/2000/01/rdf-schema#label");
+
+    public static final IRI RDFS_COMMENT = IRI.create("http://www.w3.org/2000/01/rdf-schema#comment");
+
+    public static final IRI IAO_DEFINITION = IRI.create("http://purl.obolibrary.org/obo/IAO_0000115");
+
+    public static final IRI HAS_EXACT_SYNONYM = IRI.create(OIO_PREFIX + "hasExactSynonym");
+
+    public static final IRI HAS_DBXREF = IRI.create(OIO_PREFIX + "hasDbXref");
+
+    public static final IRI TERM_REPLACED_BY = IRI.create("http://purl.obolibrary.org/obo/IAO_0100001");
 }

--- a/src/main/java/org/incenp/obofoundry/odk/EntityReplacementVisitor.java
+++ b/src/main/java/org/incenp/obofoundry/odk/EntityReplacementVisitor.java
@@ -1,6 +1,6 @@
 /*
  * ODK ROBOT Plugin
- * Copyright © 2025 Damien Goutte-Gattat
+ * Copyright © 2025 Nico Matentzoglu
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/incenp/obofoundry/odk/EntityReplacementVisitor.java
+++ b/src/main/java/org/incenp/obofoundry/odk/EntityReplacementVisitor.java
@@ -1,0 +1,89 @@
+/*
+ * ODK ROBOT Plugin
+ * Copyright © 2025 Damien Goutte-Gattat
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.incenp.obofoundry.odk;
+
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLDataProperty;
+import org.semanticweb.owlapi.model.OWLEntity;
+import org.semanticweb.owlapi.model.OWLNamedIndividual;
+import org.semanticweb.owlapi.model.OWLObjectProperty;
+import org.semanticweb.owlapi.util.OWLObjectDuplicator;
+
+/**
+ * A visitor that replaces all occurrences of one entity with another in an
+ * axiom.
+ * <p>
+ * This visitor extends {@link OWLObjectDuplicator} to traverse an axiom and
+ * replace all occurrences of a specified entity with a replacement entity.
+ */
+class EntityReplacementVisitor extends OWLObjectDuplicator {
+
+    private final OWLEntity obsolete;
+    private final OWLEntity replacement;
+
+    /**
+     * Creates a new entity replacement visitor.
+     *
+     * @param factory     The data factory to use.
+     * @param obsolete    The entity to replace.
+     * @param replacement The replacement entity.
+     */
+    public EntityReplacementVisitor(OWLDataFactory factory, OWLEntity obsolete, OWLEntity replacement) {
+        super(factory);
+        this.obsolete = obsolete;
+        this.replacement = replacement;
+    }
+
+    @Override
+    public void visit(OWLClass cls) {
+        if (cls.equals(obsolete)) {
+            setLastObject((OWLClass) replacement);
+        } else {
+            setLastObject(cls);
+        }
+    }
+
+    @Override
+    public void visit(OWLObjectProperty property) {
+        if (property.equals(obsolete)) {
+            setLastObject((OWLObjectProperty) replacement);
+        } else {
+            setLastObject(property);
+        }
+    }
+
+    @Override
+    public void visit(OWLDataProperty property) {
+        if (property.equals(obsolete)) {
+            setLastObject((OWLDataProperty) replacement);
+        } else {
+            setLastObject(property);
+        }
+    }
+
+    @Override
+    public void visit(OWLNamedIndividual individual) {
+        if (individual.equals(obsolete)) {
+            setLastObject((OWLNamedIndividual) replacement);
+        } else {
+            setLastObject(individual);
+        }
+    }
+}

--- a/src/main/java/org/incenp/obofoundry/odk/ObsoleteReplaceCommand.java
+++ b/src/main/java/org/incenp/obofoundry/odk/ObsoleteReplaceCommand.java
@@ -1,6 +1,7 @@
 /*
  * ODK ROBOT Plugin
  * Copyright © 2025 Nico Matentzoglu
+ * This Command was strongly inspired by https://github.com/owlcollab/owltools/blob/master/OWLTools-Runner/src/main/java/owltools/cli/CommandRunner.java
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/incenp/obofoundry/odk/ObsoleteReplaceCommand.java
+++ b/src/main/java/org/incenp/obofoundry/odk/ObsoleteReplaceCommand.java
@@ -1,6 +1,6 @@
 /*
  * ODK ROBOT Plugin
- * Copyright © 2025 Damien Goutte-Gattat
+ * Copyright © 2025 Nico Matentzoglu
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/org/incenp/obofoundry/odk/ObsoleteReplaceCommand.java
+++ b/src/main/java/org/incenp/obofoundry/odk/ObsoleteReplaceCommand.java
@@ -1,0 +1,195 @@
+/*
+ * ODK ROBOT Plugin
+ * Copyright © 2025 Damien Goutte-Gattat
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.incenp.obofoundry.odk;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.cli.CommandLine;
+import org.obolibrary.robot.CommandState;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnnotation;
+import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLEntity;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A command to obsolete an entity and replace all its usages with a replacement
+ * entity.
+ * <p>
+ * This command takes an entity to obsolete and a replacement entity. It will:
+ * <ul>
+ * <li>Replace all usages of the obsolete entity with the replacement entity
+ * throughout the ontology
+ * <li>Remove the label, comment, and definition from the obsolete entity
+ * <li>Mark the obsolete entity as deprecated
+ * <li>Add a new label prefixed with "obsolete" to the obsolete entity
+ * <li>Add the original label of the obsolete entity as an exact synonym on the
+ * replacement entity (with a dbxref annotation pointing to the obsolete entity)
+ * <li>Add a "term replaced by" annotation on the obsolete entity pointing to the
+ * replacement entity
+ * </ul>
+ */
+public class ObsoleteReplaceCommand extends BasePlugin {
+
+    private static final Logger logger = LoggerFactory.getLogger(ObsoleteReplaceCommand.class);
+
+    public ObsoleteReplaceCommand() {
+        super("obsolete-replace", "obsolete an entity and replace it with another",
+                "robot obsolete-replace --obsolete TERM --replacement TERM");
+
+        options.addOption(null, "obsolete", true, "entity to obsolete (CURIE or IRI)");
+        options.addOption(null, "replacement", true, "replacement entity (CURIE or IRI)");
+    }
+
+    @Override
+    public void performOperation(CommandState state, CommandLine line) throws Exception {
+        if (!line.hasOption("obsolete") || !line.hasOption("replacement")) {
+            throw new IllegalArgumentException("Both --obsolete and --replacement options are required");
+        }
+
+        IRI obsoleteIRI = getIRI(line.getOptionValue("obsolete"), "obsolete");
+        IRI replacementIRI = getIRI(line.getOptionValue("replacement"), "replacement");
+
+        OWLOntology ontology = state.getOntology();
+        OWLOntologyManager manager = ontology.getOWLOntologyManager();
+        OWLDataFactory factory = manager.getOWLDataFactory();
+
+        OWLEntity obsoleteEntity = getEntity(ontology, obsoleteIRI);
+        if (obsoleteEntity == null) {
+            throw new IllegalArgumentException("Entity not found: " + obsoleteIRI);
+        }
+
+        OWLEntity replacementEntity = getEntity(ontology, replacementIRI);
+        if (replacementEntity == null) {
+            throw new IllegalArgumentException("Replacement entity not found: " + replacementIRI);
+        }
+
+        String originalLabel = getLabel(ontology, obsoleteIRI);
+
+        Set<OWLAxiom> axiomsToRemove = new HashSet<>();
+        for (OWLAnnotationAssertionAxiom axiom : ontology.getAnnotationAssertionAxioms(obsoleteIRI)) {
+            IRI propertyIRI = axiom.getProperty().getIRI();
+            if (propertyIRI.equals(Constants.RDFS_LABEL) || propertyIRI.equals(Constants.RDFS_COMMENT)
+                    || propertyIRI.equals(Constants.IAO_DEFINITION)) {
+                axiomsToRemove.add(axiom);
+            }
+        }
+
+        logger.info("Removing {} annotation axioms from obsolete entity", axiomsToRemove.size());
+        manager.removeAxioms(ontology, axiomsToRemove);
+
+        replaceEntity(ontology, obsoleteEntity, replacementEntity);
+
+        Set<OWLAxiom> axiomsToAdd = new HashSet<>();
+        axiomsToAdd.add(factory.getOWLDeclarationAxiom(obsoleteEntity));
+        axiomsToAdd.add(factory.getOWLAnnotationAssertionAxiom(factory.getOWLDeprecated(), obsoleteIRI,
+                factory.getOWLLiteral(true)));
+
+        String newLabel = "obsolete " + (originalLabel != null ? originalLabel : getLocalName(obsoleteIRI));
+        axiomsToAdd.add(factory.getOWLAnnotationAssertionAxiom(factory.getRDFSLabel(), obsoleteIRI,
+                factory.getOWLLiteral(newLabel)));
+
+        if (originalLabel != null) {
+            OWLAnnotationProperty hasExactSynonym = factory.getOWLAnnotationProperty(Constants.HAS_EXACT_SYNONYM);
+            OWLAnnotationProperty hasDbXref = factory.getOWLAnnotationProperty(Constants.HAS_DBXREF);
+            OWLAnnotation dbxrefAnnotation = factory.getOWLAnnotation(hasDbXref,
+                    factory.getOWLLiteral(getShortForm(obsoleteIRI)));
+            Set<OWLAnnotation> synonymAnnotations = Collections.singleton(dbxrefAnnotation);
+            axiomsToAdd.add(factory.getOWLAnnotationAssertionAxiom(hasExactSynonym, replacementIRI,
+                    factory.getOWLLiteral(originalLabel), synonymAnnotations));
+        }
+
+        OWLAnnotationProperty termReplacedBy = factory.getOWLAnnotationProperty(Constants.TERM_REPLACED_BY);
+        axiomsToAdd.add(factory.getOWLAnnotationAssertionAxiom(termReplacedBy, obsoleteIRI,
+                factory.getOWLLiteral(getShortForm(replacementIRI))));
+
+        logger.info("Adding {} new axioms to obsolete entity and replacement", axiomsToAdd.size());
+        manager.addAxioms(ontology, axiomsToAdd);
+    }
+
+    private OWLEntity getEntity(OWLOntology ontology, IRI iri) {
+        for (OWLEntity entity : ontology.getSignature()) {
+            if (entity.getIRI().equals(iri)) {
+                return entity;
+            }
+        }
+        return null;
+    }
+
+    private String getLabel(OWLOntology ontology, IRI entityIRI) {
+        for (OWLAnnotationAssertionAxiom axiom : ontology.getAnnotationAssertionAxioms(entityIRI)) {
+            if (axiom.getProperty().isLabel() && axiom.getValue().isLiteral()) {
+                return axiom.getValue().asLiteral().get().getLiteral();
+            }
+        }
+        return null;
+    }
+
+    private void replaceEntity(OWLOntology ontology, OWLEntity obsolete, OWLEntity replacement) {
+        OWLOntologyManager manager = ontology.getOWLOntologyManager();
+        OWLDataFactory factory = manager.getOWLDataFactory();
+        Set<OWLAxiom> axiomsToRemove = new HashSet<>();
+        Set<OWLAxiom> axiomsToAdd = new HashSet<>();
+
+        for (OWLAxiom axiom : ontology.getAxioms()) {
+            if (axiom.getSignature().contains(obsolete)) {
+                axiomsToRemove.add(axiom);
+                OWLAxiom replacedAxiom = replaceInAxiom(axiom, factory, obsolete, replacement);
+                axiomsToAdd.add(replacedAxiom);
+            }
+        }
+
+        logger.info("Replacing {} axioms containing the obsolete entity", axiomsToRemove.size());
+        manager.removeAxioms(ontology, axiomsToRemove);
+        manager.addAxioms(ontology, axiomsToAdd);
+    }
+
+    private OWLAxiom replaceInAxiom(OWLAxiom axiom, OWLDataFactory factory, OWLEntity obsolete,
+            OWLEntity replacement) {
+        EntityReplacementVisitor visitor = new EntityReplacementVisitor(factory, obsolete, replacement);
+        axiom.accept(visitor);
+        return visitor.duplicateObject(axiom);
+    }
+
+    private String getShortForm(IRI iri) {
+        String iriString = iri.toString();
+        if (iriString.contains("#")) {
+            return iriString.substring(iriString.lastIndexOf('#') + 1);
+        } else if (iriString.contains("/")) {
+            return iriString.substring(iriString.lastIndexOf('/') + 1);
+        }
+        return iriString;
+    }
+
+    private String getLocalName(IRI iri) {
+        String shortForm = getShortForm(iri);
+        if (shortForm.contains("_")) {
+            return shortForm.replace('_', ':');
+        }
+        return shortForm;
+    }
+}

--- a/src/main/java/org/incenp/obofoundry/odk/StandaloneRobot.java
+++ b/src/main/java/org/incenp/obofoundry/odk/StandaloneRobot.java
@@ -84,6 +84,7 @@ public class StandaloneRobot {
         m.addCommand("validate-profile", new ValidateProfileCommand());
         m.addCommand("verify", new VerifyCommand());
         m.addCommand("odk:normalize", new NormalizeCommand());
+        m.addCommand("odk:obsolete-replace", new ObsoleteReplaceCommand());
         m.addCommand("odk:subset", new SubsetCommand());
         m.addCommand("odk:validate", new CheckAlignmentCommand());
 

--- a/src/main/resources/META-INF/services/org.obolibrary.robot.Command
+++ b/src/main/resources/META-INF/services/org.obolibrary.robot.Command
@@ -3,3 +3,4 @@ org.incenp.obofoundry.odk.SubsetCommand
 org.incenp.obofoundry.odk.CheckAlignmentCommand
 org.incenp.obofoundry.odk.ImportCommand
 org.incenp.obofoundry.odk.CheckCommand
+org.incenp.obofoundry.odk.ObsoleteReplaceCommand

--- a/src/site/markdown/obsolete-replace.md
+++ b/src/site/markdown/obsolete-replace.md
@@ -1,0 +1,57 @@
+Obsoleting and replacing entities
+=================================
+
+The `odk:obsolete-replace` command is intended to obsolete an entity and
+replace all its usages with a replacement entity in a single operation.
+
+This is useful when merging terms or when an entity needs to be retired
+but its usages should be redirected to another term.
+
+Basic usage
+-----------
+The command requires two options:
+
+* `--obsolete <TERM>`: The entity to obsolete (CURIE or IRI)
+* `--replacement <TERM>`: The replacement entity (CURIE or IRI)
+
+Example:
+
+```
+robot odk:obsolete-replace --input ontology.owl \
+                           --obsolete EXAMPLE:0000001 \
+                           --replacement EXAMPLE:0000002 \
+                           --output output.owl
+```
+
+What the command does
+---------------------
+When executed, the command performs the following operations:
+
+1. **Replaces all usages** of the obsolete entity with the replacement
+   entity throughout the ontology (in all axioms)
+2. **Removes annotations** from the obsolete entity: label, comment, and
+   definition (IAO:0000115)
+3. **Marks the obsolete entity as deprecated** by adding an
+   `owl:deprecated true` annotation
+4. **Adds a new label** to the obsolete entity, prefixed with "obsolete"
+   (e.g., "obsolete old term name")
+5. **Adds the original label as an exact synonym** on the replacement
+   entity, with a database cross-reference annotation pointing to the
+   obsolete entity
+6. **Adds a "term replaced by" annotation** (IAO:0100001) on the
+   obsolete entity pointing to the replacement entity
+
+Example workflow
+----------------
+A typical workflow might look like:
+
+```
+robot merge --input ontology.owl \
+      odk:obsolete-replace --obsolete GO:0000001 \
+                           --replacement GO:0000002 \
+      annotate --ontology-iri http://example.org/ontology.owl \
+               --output output.owl
+```
+
+This merges the ontology, obsoletes `GO:0000001` replacing it with
+`GO:0000002`, and then annotates and saves the result.


### PR DESCRIPTION
Adding the odk:obsolete-replace command to replace a key command of the owltools stack, eg:

```
owltools --use-catalog edit.obo --obsolete-replace http://purl.obolibrary.org/obo/VBO_0000012 http://purl.obolibrary.org/obo/VBO_0000038 -o -f obo edit.obo
```

The command essentially:

1. obsoletes one term
2. moves selected properties over to the replacement term

I changed the interface a little but (for now) left the (owltools) implementation more or less what it was. I tested this in Mondo and it works as expected.

I contemplated adding this to my custom Monarch plugin but since this is used by at least two ontologies I know off, I thought ODK ROBOT plugin might be the right place. Correct me if I am wrong, happy to migrate this over.